### PR TITLE
Added retry mechanism for registry apis and fixed a couple of issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evergreen-org-crawler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,39 @@ export function getAccessToken(): string {
 	}
 }
 
+
+/**
+ * retry retries an function up to maxAttempts times.
+ * If maxAttempts is exceed, a list containing all thrown errors will be returned
+ */
+export async function retry<T>(f:()=>Promise<T>, maxAttempts:number):Promise<T>{
+
+	if (maxAttempts > 3){
+		console.warn(`Wait time for retrying will be up to: ${Math.pow(10, maxAttempts)} milliseconds`)
+	}
+
+	const errors:Error[] = []
+
+	for (let i = 0; i < maxAttempts; i ++){
+		try {
+			return await f()
+		}catch(e){
+			// i < maxAttempts - 1 && console.warn("Retrying a failed request")
+			// console.warn(e.errors.message)
+			if(e instanceof Error){
+				errors.push(e)
+			} else{
+				console.log("Error of unknown type in retry:")
+				console.log(e)
+				errors.push(new Error())
+			}
+			await sleep(Math.pow(10, i + 1))
+		}
+	}
+
+	throw errors
+}
+
 export type Configuration = {
 	npmURL?: string,
 	pipURL?: string,


### PR DESCRIPTION
Because of timeouts, I did some rate limiting analysis, and I had to Lower NPM rate limit for npm from ~1.9 to ~1.5 requests per second.

The biggest bottleneck by far is the public NPM registry,  at the moment we are fetching 250 packages as quickly as possible and then we gradually decrease to ~1.6 requests per second. Going any faster results in timeout. NPM doesn't document their rate limits https://github.com/npm/feedback/discussions/658

I tested the Vercel GitHub organization which has 118 repositories and 1107 npm dependencies. It took ~9mins in total of which ~8min was spent querying NPM registry.

fixed issue where the default value for npm failure was `1.0.0` instead of `0.0.0`.